### PR TITLE
Update controllers/GuestTrackingController.php

### DIFF
--- a/controllers/GuestTrackingController.php
+++ b/controllers/GuestTrackingController.php
@@ -134,7 +134,7 @@ class GuestTrackingControllerCore extends FrontController
 		if (sizeof($this->errors))			
 			sleep(1);
 		
-		self::$smarty->assign(array('action' => $link->getPageLink('guest-tracking.php'), 'errors' => $this->errors));
+		self::$smarty->assign(array('action' => $link->getPageLink('guest-tracking.php', true), 'errors' => $this->errors));
 	}
 	
 	public function setMedia()


### PR DESCRIPTION
Guest tracking is not using a secure connection when it is submitted and it reloads the page. This makes it use a secure connection.
